### PR TITLE
fix(chalisa): restore correct doha ordering on full-chalisa page

### DIFF
--- a/chalisa/full-chalisa.html
+++ b/chalisa/full-chalisa.html
@@ -24,18 +24,21 @@ description: "Read the complete Hanuman Chalisa with all 43 verses on a single p
         {% assign sorted_verses = collection_verses | sort: 'url' %}
         {% assign ordered_verses = "" | split: "" %}
 
-        {% comment %} Build ordered array: doha_01, doha_02, verse_01-40, doha_closing {% endcomment %}
+        {% comment %} Build ordered array: doha-01, doha-02, chaupai-01..40, doha-closing {% endcomment %}
         {% for verse in sorted_verses %}
-            {% assign verse_id = verse.url | split: '/' | last %}
-            {% unless verse_id == 'doha_closing' %}
+            {% if verse.url contains '/doha-01' or verse.url contains '/doha-02' %}
                 {% assign ordered_verses = ordered_verses | push: verse %}
-            {% endunless %}
+            {% endif %}
         {% endfor %}
 
-        {% comment %} Add closing doha at the end {% endcomment %}
         {% for verse in sorted_verses %}
-            {% assign verse_id = verse.url | split: '/' | last %}
-            {% if verse_id == 'doha_closing' %}
+            {% if verse.url contains '/chaupai-' %}
+                {% assign ordered_verses = ordered_verses | push: verse %}
+            {% endif %}
+        {% endfor %}
+
+        {% for verse in sorted_verses %}
+            {% if verse.url contains '/doha-closing' %}
                 {% assign ordered_verses = ordered_verses | push: verse %}
             {% endif %}
         {% endfor %}


### PR DESCRIPTION
## Summary

- Fixes missing Doha 1 & Doha 2 at the top of the Complete Chalisa page
- Fixes misplaced closing doha (was sorted to the middle alphabetically)
- Replaces fragile URL-sort approach with explicit three-pass ordering

Closes #26

## Root cause

Two bugs in `chalisa/full-chalisa.html`:

1. `sort: 'url'` sorted verses alphabetically — `chaupai-*` URLs come before `doha-*` URLs (`c` < `d`), so all 40 chaupais appeared first and the dohas fell to the bottom.
2. The closing-doha check used `doha_closing` (underscore) but the actual slug is `doha-closing` (hyphen), so the fix-up loop never matched and was silently a no-op.

## Fix

Three explicit passes build `ordered_verses` in canonical sequence:
1. URLs containing `/doha-01` or `/doha-02` (opening dohas)
2. URLs containing `/chaupai-` (chaupais 1–40)
3. URLs containing `/doha-closing` (closing doha)

## Test plan

- [ ] Visit `/chalisa/full-chalisa` and confirm Doha 1 appears first, Doha 2 second
- [ ] Confirm Chaupai 1–40 follow in order
- [ ] Confirm Closing Doha appears last

🤖 Generated with [Claude Code](https://claude.com/claude-code)